### PR TITLE
Answer retrieval

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -10,22 +10,22 @@ function NavBar({ accessLevel, username }) {
             <Link to="/help">
                 <button>How To SAT Solve</button>
             </Link>
-            {accessLevel == ACCESS_LEVELS.LOGGED_OUT && (
+            {accessLevel === ACCESS_LEVELS.LOGGED_OUT && (
                 <Link to="/login">
                     <button>Log In</button>
                 </Link>
             )}
-            {accessLevel == ACCESS_LEVELS.LOGGED_OUT && (
+            {accessLevel === ACCESS_LEVELS.LOGGED_OUT && (
                 <Link to="/signup">
                     <button>Sign Up</button>
                 </Link>
             )}
-            {accessLevel >= ACCESS_LEVELS.RESEARCHER && (
+            {(accessLevel === ACCESS_LEVELS.RESEARCHER || accessLevel === ACCESS_LEVELS.ADMIN) && (
                 <Link to="/upload">
                     <button>Upload Problem</button>
                 </Link>
             )}
-            {accessLevel >= ACCESS_LEVELS.USER && (
+            {accessLevel != ACCESS_LEVELS.LOGGED_OUT && (
                 <Link to={`/user/${username}`}>
                     <button>My Profile</button>
                 </Link>

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -1,49 +1,37 @@
-import { Link, } from 'react-router-dom'
-import ACCESS_LEVELS from '../logic/accessLevels'
-
+import { Link } from "react-router-dom";
+import ACCESS_LEVELS from "../logic/accessLevels";
 
 function NavBar({ accessLevel, username }) {
     return (
         <nav>
-            <Link to='/'>
-                <button>
-                    Home
-                </button>
+            <Link to="/">
+                <button>Home</button>
             </Link>
-            {
-                accessLevel == ACCESS_LEVELS.LOGGED_OUT &&
-                <Link to='/login'>
-                    <button>
-                        Log In
-                    </button>
+            <Link to="/help">
+                <button>How To SAT Solve</button>
+            </Link>
+            {accessLevel == ACCESS_LEVELS.LOGGED_OUT && (
+                <Link to="/login">
+                    <button>Log In</button>
                 </Link>
-            }
-            {
-                accessLevel == ACCESS_LEVELS.LOGGED_OUT &&
-                <Link to='/signup'>
-                    <button>
-                        Sign Up
-                    </button>
+            )}
+            {accessLevel == ACCESS_LEVELS.LOGGED_OUT && (
+                <Link to="/signup">
+                    <button>Sign Up</button>
                 </Link>
-            }
-            {
-                accessLevel >= ACCESS_LEVELS.RESEARCHER &&
-                <Link to='/upload'>
-                    <button>
-                        Upload Problem
-                    </button>
+            )}
+            {accessLevel >= ACCESS_LEVELS.RESEARCHER && (
+                <Link to="/upload">
+                    <button>Upload Problem</button>
                 </Link>
-            }
-            {
-                accessLevel >= ACCESS_LEVELS.USER &&
+            )}
+            {accessLevel >= ACCESS_LEVELS.USER && (
                 <Link to={`/user/${username}`}>
-                    <button>
-                        My Profile
-                    </button>
+                    <button>My Profile</button>
                 </Link>
-            }
+            )}
         </nav>
-    )
+    );
 }
 
-export default NavBar
+export default NavBar;

--- a/client/src/components/ProblemCard.jsx
+++ b/client/src/components/ProblemCard.jsx
@@ -1,12 +1,15 @@
 import { Link, } from 'react-router-dom'
 import "./ProblemCard.css"
 
-function ProblemCard({ problem}) {
+function ProblemCard({ problem }) {
     return (
         <div className='problem-card'>
             <h3><Link to={`problem/${problem.id}`}>{problem.name}</Link></h3>
             <p>
                 <b>Created By {problem.user.username}</b>
+            </p>
+            <p>
+                Size: {problem.current_size}
             </p>
             <p>
                 {problem.description.length > 100 ? problem.description.substring(0, 100) + "..." : problem.description}

--- a/client/src/components/ProblemCard.jsx
+++ b/client/src/components/ProblemCard.jsx
@@ -4,7 +4,7 @@ import "./ProblemCard.css"
 function ProblemCard({ problem }) {
     return (
         <div className='problem-card'>
-            <h3><Link to={`problem/${problem.id}`}>{problem.name}</Link></h3>
+            <h3><Link to={`problem/${problem.id}`}>{problem.name} {!problem.is_active && `[SOLVED]`}</Link></h3>
             <p>
                 <b>Created By {problem.user.username}</b>
             </p>

--- a/client/src/components/VariableAssignment.jsx
+++ b/client/src/components/VariableAssignment.jsx
@@ -11,4 +11,4 @@ const VariableAssignmentComponent = ({ assignment, removeFunction }) => {
     );
 };
 
-export default VariableAssignmentComponent
+export default VariableAssignmentComponent;

--- a/client/src/pages/ProblemPage.jsx
+++ b/client/src/pages/ProblemPage.jsx
@@ -31,7 +31,6 @@ function ProblemPage() {
         const req = await makeGetRequest(`problem/${problemId}/file`);
         if (req.status === 200) {
             const data = (await req.json()).problem;
-            console.log(data);
             downloadTxtFile(data.file.problem_file, data.name);
             downloadTxtFile(data.file.solution_file, data.name, "symsln");
         } else {

--- a/client/src/pages/ProblemPage.jsx
+++ b/client/src/pages/ProblemPage.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { makeGetRequest } from '../logic/requestTemplates';
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { makeGetRequest } from "../logic/requestTemplates";
 function ProblemPage() {
     const navigate = useNavigate();
     const { problemId } = useParams();
@@ -14,33 +14,61 @@ function ProblemPage() {
             setProblem(data.problem);
             setIsLoaded(true);
         } else {
-            navigate('/');
+            navigate("/");
         }
+    };
+    // Modified code from stack overflow
+    // https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
+    const downloadTxtFile = (text, filename) => {
+        const element = document.createElement("a");
+        const file = new Blob([text], { type: 'text/plain' });
+        element.href = URL.createObjectURL(file);
+        element.download = `${filename}.cnf`;
+        document.body.appendChild(element); // Required for this to work in FireFox
+        element.click();
     }
-    useEffect(() => { getProblem(); }, [problemId])
+    const downloadSolution = async () => {
+        const req = await makeGetRequest(`problem/${problemId}/file`);
+        if (req.status === 200) {
+            const data = (await req.json()).problem;
+            console.log(data)
+            downloadTxtFile(data.file.problem_file, data.name)
+        } else {
+            navigate("/");
+        }
+    };
+
+    useEffect(() => {
+        getProblem();
+    }, [problemId]);
 
     if (!isLoaded) {
         return (
             <div>
-                <p>
-                    Loading...
-                </p>
+                <p>Loading...</p>
             </div>
-        )
+        );
     } else {
         return (
             <div>
-                <Link to="/"> <p>Return Home</p></Link>
+                <Link to="/">
+                    {" "}
+                    <p>Return Home</p>
+                </Link>
                 <h1>{problem.name}</h1>
                 <h3>By {problem.user.username}</h3>
                 <p>{problem.description}</p>
-                {problem.is_active ?
-                    <Link to={`/problem/${problemId}/solver`}> <button>Solve</button></Link>
-                    : <button>Download Solution </button>
-                }
+                {problem.is_active ? (
+                    <Link to={`/problem/${problemId}/solver`}>
+                        {" "}
+                        <button>Solve</button>
+                    </Link>
+                ) : (
+                    <button onClick={downloadSolution}>Download Solution </button>
+                )}
             </div>
-        )
+        );
     }
 }
 
-export default ProblemPage
+export default ProblemPage;

--- a/client/src/pages/ProblemPage.jsx
+++ b/client/src/pages/ProblemPage.jsx
@@ -34,7 +34,10 @@ function ProblemPage() {
                 <h1>{problem.name}</h1>
                 <h3>By {problem.user.username}</h3>
                 <p>{problem.description}</p>
-                <Link to={`/problem/${problemId}/solver`}> <button>Solve</button></Link>
+                {problem.is_active ?
+                    <Link to={`/problem/${problemId}/solver`}> <button>Solve</button></Link>
+                    : <button>Download Solution </button>
+                }
             </div>
         )
     }

--- a/client/src/pages/ProblemPage.jsx
+++ b/client/src/pages/ProblemPage.jsx
@@ -19,20 +19,21 @@ function ProblemPage() {
     };
     // Modified code from stack overflow
     // https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
-    const downloadTxtFile = (text, filename) => {
+    const downloadTxtFile = (text, filename, extension = "cnf") => {
         const element = document.createElement("a");
-        const file = new Blob([text], { type: 'text/plain' });
+        const file = new Blob([text], { type: "text/plain" });
         element.href = URL.createObjectURL(file);
-        element.download = `${filename}.cnf`;
+        element.download = `${filename}.${extension}`;
         document.body.appendChild(element); // Required for this to work in FireFox
         element.click();
-    }
+    };
     const downloadSolution = async () => {
         const req = await makeGetRequest(`problem/${problemId}/file`);
         if (req.status === 200) {
             const data = (await req.json()).problem;
-            console.log(data)
-            downloadTxtFile(data.file.problem_file, data.name)
+            console.log(data);
+            downloadTxtFile(data.file.problem_file, data.name);
+            downloadTxtFile(data.file.solution_file, data.name, "symsln");
         } else {
             navigate("/");
         }

--- a/client/src/pages/ProblemPage.jsx
+++ b/client/src/pages/ProblemPage.jsx
@@ -1,38 +1,59 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { makeGetRequest } from "../logic/requestTemplates";
+import { getSizeCNF } from "../logic/boolsat";
 function ProblemPage() {
     const navigate = useNavigate();
     const { problemId } = useParams();
     const [isLoaded, setIsLoaded] = useState(false);
     const [problem, setProblem] = useState({});
+    const [downloadButton, setDownloadButton] = useState(<></>);
 
     const getProblem = async () => {
         const res = await makeGetRequest(`problem/${problemId}`);
         if (res.status === 200) {
             const data = await res.json();
             setProblem(data.problem);
+            if (!data.problem.is_active) {
+                await setupDownloadButton();
+            }
             setIsLoaded(true);
         } else {
             navigate("/");
         }
     };
     // Modified code from stack overflow
-    // https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
-    const downloadTxtFile = (text, filename, extension = "cnf") => {
-        const element = document.createElement("a");
-        const file = new Blob([text], { type: "text/plain" });
-        element.href = URL.createObjectURL(file);
-        element.download = `${filename}.${extension}`;
-        document.body.appendChild(element); // Required for this to work in FireFox
-        element.click();
-    };
-    const downloadSolution = async () => {
+    // https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react/76922730#76922730
+    const setupDownloadButton = async () => {
         const req = await makeGetRequest(`problem/${problemId}/file`);
         if (req.status === 200) {
             const data = (await req.json()).problem;
-            downloadTxtFile(data.file.problem_file, data.name);
-            downloadTxtFile(data.file.solution_file, data.name, "symsln");
+            let problemFile = data.file.problem_file;
+            let fileToDownload = data.file.problem_file;
+            let isSolvable = true;
+            if (problemFile.substring(0, 9) === "p cnf 0 1") {
+                //this means the problem is unsolvable, download the justification
+                isSolvable = false;
+                fileToDownload = data.file.solution_file;
+            }
+            const file = new Blob([fileToDownload], { type: "text/plain" });
+
+            setDownloadButton(
+                <button variant="outlined">
+                    <a
+                        download={isSolvable ? "solution.cnf" : "justification.txt"}
+                        target="_blank"
+                        rel="noreferrer"
+                        href={URL.createObjectURL(file)}
+                        style={{
+                            textDecoration: "inherit",
+                            color: "inherit",
+                        }}
+                    >
+                        Download
+                    </a>
+                </button>
+            );
         } else {
             navigate("/");
         }
@@ -64,7 +85,7 @@ function ProblemPage() {
                         <button>Solve</button>
                     </Link>
                 ) : (
-                    <button onClick={downloadSolution}>Download Solution </button>
+                    downloadButton
                 )}
             </div>
         );

--- a/client/src/pages/SolverPage.jsx
+++ b/client/src/pages/SolverPage.jsx
@@ -23,19 +23,19 @@ function SolverPage() {
     const [solutionSteps, setSolutionSteps] = useState([]);
     const [error, setError] = useState("");
     const [sidePage, setSidePage] = useState(SOLVER_PAGE.STEPS);
-    const [sidePageData, setSidePageData] = useState({});
+
     const getProblem = async () => {
         const res = await makeGetRequest(`problem/${problemId}/file`);
         if (res.status === 200) {
             const data = await res.json();
-            console.log(data)
+            console.log(data);
             if (data.problem.is_active) {
                 setProblem(data.problem);
                 setIsLoaded(true);
                 setClauses(data.problem.file.problem_file);
                 setProblemSize(getSizeCNF(data.problem.file.problem_file));
             } else {
-                navigate("/")
+                navigate("/");
             }
         } else {
             navigate("/");
@@ -68,9 +68,7 @@ function SolverPage() {
         } else if (step.type === "partial-solve") {
             return (
                 <div>
-                    <p>
-                        Partial Solve (Assignments: {step.assignments.join(", ")})
-                    </p>
+                    <p>Partial Solve (Assignments: {step.assignments.join(", ")})</p>
                 </div>
             );
         } else {
@@ -87,15 +85,17 @@ function SolverPage() {
         newSolutionSteps.push({ type: "resolution", old: [clause1, clause2], new: newClause });
         setSolutionSteps(newSolutionSteps);
         addClauses([newClause]);
-    }
+    };
     const submitPartialSolve = (assignments) => {
         let newSolutionSteps = solutionSteps;
-        newSolutionSteps.push({ type: "partial-solve", assignments, });
+        newSolutionSteps.push({ type: "partial-solve", assignments });
         setSolutionSteps(newSolutionSteps);
-        let assignmentClauses = assignments.map((assignment) => { return [assignment]; });
+        let assignmentClauses = assignments.map((assignment) => {
+            return [assignment];
+        });
         addClauses(assignmentClauses);
-        setSidePage(SOLVER_PAGE.STEPS)
-    }
+        setSidePage(SOLVER_PAGE.STEPS);
+    };
     const addClauses = (newClauses) => {
         let toAdd = newClauses;
         let newClausesList = clauses.slice(); //slice to make a copy, triggering re-render;
@@ -213,7 +213,7 @@ function SolverPage() {
             }
         } else {
             //length 1 clauses are useful for data, but not for solving. They can be handled automatically!
-            clauseList = clauses //.filter((clause) => { return clause.length > 1; });
+            clauseList = clauses; //.filter((clause) => { return clause.length > 1; });
             clauseList = clauseList
                 .slice(startIndex * 100, startIndex * 100 + 100)
                 .map((clause, index) => {
@@ -270,7 +270,6 @@ function SolverPage() {
                         <div>
                             <button
                                 onClick={() => {
-                                    setSidePageData({});
                                     setSidePage(SOLVER_PAGE.STEPS);
                                 }}
                             >
@@ -278,9 +277,6 @@ function SolverPage() {
                             </button>
                             <button
                                 onClick={() => {
-                                    setSidePageData({
-                                        assignments: [],
-                                    });
                                     setSidePage(SOLVER_PAGE.PARTIAL_SOLVE);
                                 }}
                             >
@@ -313,7 +309,10 @@ function SolverPage() {
                             </>
                         )}
                         {sidePage === SOLVER_PAGE.PARTIAL_SOLVE && (
-                            <PartialSolveMenu clauses={clauses} submitPartialSolve={submitPartialSolve} />
+                            <PartialSolveMenu
+                                clauses={clauses}
+                                submitPartialSolve={submitPartialSolve}
+                            />
                         )}
                     </div>
                 </div>

--- a/client/src/pages/SolverPage.jsx
+++ b/client/src/pages/SolverPage.jsx
@@ -28,10 +28,15 @@ function SolverPage() {
         const res = await makeGetRequest(`problem/${problemId}/file`);
         if (res.status === 200) {
             const data = await res.json();
-            setProblem(data.problem);
-            setIsLoaded(true);
-            setClauses(data.problem.file.problem_file);
-            setProblemSize(getSizeCNF(data.problem.file.problem_file));
+            console.log(data)
+            if (data.problem.is_active) {
+                setProblem(data.problem);
+                setIsLoaded(true);
+                setClauses(data.problem.file.problem_file);
+                setProblemSize(getSizeCNF(data.problem.file.problem_file));
+            } else {
+                navigate("/")
+            }
         } else {
             navigate("/");
         }

--- a/client/src/pages/SolverPage.jsx
+++ b/client/src/pages/SolverPage.jsx
@@ -28,7 +28,6 @@ function SolverPage() {
         const res = await makeGetRequest(`problem/${problemId}/file`);
         if (res.status === 200) {
             const data = await res.json();
-            console.log(data);
             if (data.problem.is_active) {
                 setProblem(data.problem);
                 setIsLoaded(true);

--- a/server/benchmark/benchmark.js
+++ b/server/benchmark/benchmark.js
@@ -124,8 +124,8 @@ async function makeChoice(options) {
     return options[input - 1];
 }
 
-rl.on('SIGINT', () => {
-    console.log('\nCtrl+C detected. Exiting...');
+rl.on("SIGINT", () => {
+    console.log("\nCtrl+C detected. Exiting...");
     rl.close(); // Close the readline interface
     process.exit(0); // Exit the process
 });
@@ -137,7 +137,7 @@ async function main() {
     console.log("\t(2) Benchmark a specific problem set");
     console.log("\t(3) Examine output of reducing a specific problem");
     let input = await getConsoleInput();
-    while (!["1","2","3","4"].includes(input)) {
+    while (!["1", "2", "3", "4"].includes(input)) {
         console.log("Invalid input. Please enter a, b, c, or d");
         input = await getConsoleInput();
     }

--- a/server/index.js
+++ b/server/index.js
@@ -86,7 +86,7 @@ app.post("/api/signup", express.json(), async (req, res) => {
 
 app.post("/api/login", express.json(), async (req, res) => {
     const { username, password: plainPassword } = req.body;
-    if(!username || !plainPassword) {
+    if (!username || !plainPassword) {
         badRequestError(res, "Username and password required", 400);
         return;
     }
@@ -114,7 +114,7 @@ app.post("/api/logout", express.json(), (req, res) => {
 app.get("/api/user/:username", express.json(), async (req, res) => {
     const { username } = req.params;
     let isMe = req.session.user?.username === username;
-    if(!username) {
+    if (!username) {
         badRequestError(res, "Invalid request", 400);
         return;
     }
@@ -200,7 +200,7 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         badRequestError(res, "No solution provided", 400);
         return;
     }
-    if(isNaN(parseInt(problemId))){
+    if (isNaN(parseInt(problemId))) {
         badRequestError(res, "Invalid problem ID", 400);
         return;
     }
@@ -208,7 +208,7 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         where: { id: parseInt(problemId) },
         include: { file: true },
     });
-    if(!problem){
+    if (!problem) {
         badRequestError(res, "Problem not found", 404);
         return;
     }
@@ -248,8 +248,8 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         } else if (step.type === "partial-solve") {
             if (verifyPartialAssignment(problemCNF, step.assignments)) {
                 let newClauses = [];
-                for(const assignment of step.assignments) {
-                    newClauses.push([assignment])
+                for (const assignment of step.assignments) {
+                    newClauses.push([assignment]);
                 }
                 problemCNF = reduceCNF(newClauses, problemCNF);
             } else {
@@ -266,10 +266,24 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         badRequestError(res, "Size Not Reduced", 400);
         return;
     }
+    let isSolved = true;
+    for (const clause in problemCNF) {
+        if (clause.length > 2) {
+            isSolved = false;
+            break;
+        }
+    }
     const sizeReduction = oldSize - newSize;
     const newProblemFileData = {
         problem_file: stringifyCNF(problemCNF),
         solution_file: solutionFile,
+        problem_post: {
+            update: {
+                current_size: getSizeCNF(problemCNF),
+                date_modified: (new Date()),
+                is_active: !isSolved,
+            },
+        },
     };
     const update = await prisma.problemFile.update({
         where: { id: problem.file.id },

--- a/server/index.js
+++ b/server/index.js
@@ -290,6 +290,16 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         where: { id: problem.file.id },
         data: newProblemFileData,
     });
+
+    let newTotalReduction = req.session.user.total_size_reduced + (oldSize - newSize);
+    const newUser = await prisma.user.update({
+        where: { id: req.session.user.id },
+        data: {
+            total_size_reduced: newTotalReduction,
+        },
+    });
+    console.log(newUser);
+    req.session.user = newUser;
     //TODO: Update size on the problem page
     res.json(update);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -160,7 +160,8 @@ app.post("/api/upload", upload.single("file"), async (req, res) => {
             badRequestError(res, "Invalid CNF", 400);
         } else {
             let originalProblem = fileContents;
-            let reducedProblem = stringifyCNF(reduceCNF(parseCNF(fileContents)));
+            let reducedProblemCNF = reduceCNF(parseCNF(fileContents));
+            let reducedProblem = stringifyCNF(reducedProblemCNF);
             const reductionData = {
                 original_size: getSizeCNF(parseCNF(originalProblem)),
                 reduced_size: getSizeCNF(parseCNF(reducedProblem)),
@@ -169,10 +170,17 @@ app.post("/api/upload", upload.single("file"), async (req, res) => {
                 problem_file: reducedProblem,
                 solution_file: "",
             };
-
+            let solved = true;
+            for(const clause of reducedProblemCNF){
+                if(clause.length > 1){
+                    solved = false;
+                    break;
+                }
+            }
             const newUploadData = {
                 name: title,
                 description,
+                is_active: !solved,
                 current_size: getSizeCNF(parseCNF(reducedProblem)),
                 file: { create: problemFileData },
                 user: { connect: { id: req.session.user.id } },

--- a/server/index.js
+++ b/server/index.js
@@ -256,6 +256,7 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
                 badRequestError(res, "Invalid partial solve", 400);
                 return;
             }
+            solutionFile += `Partial ${step.assignments.join(" / ")}\n`;
         } else {
             badRequestError(res, `Invalid step type - What is ${step.type}?`, 400);
             return;
@@ -368,7 +369,11 @@ app.get("/api/problem/:problemId/file", express.json(), async (req, res) => {
         if (!problem) {
             badRequestError(res, "Problem Not Found", 404);
         } else {
-            problem.file.problem_file = parseCNF(problem.file.problem_file);
+            if (problem.is_active) {
+                //if active, parse the CNF file for the solver.
+                //Otherwise, don't parse it and leave it to be downloaded
+                problem.file.problem_file = parseCNF(problem.file.problem_file);
+            }
             res.json({ problem: problem });
         }
     }

--- a/server/index.js
+++ b/server/index.js
@@ -204,8 +204,8 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         badRequestError(res, "Invalid problem ID", 400);
         return;
     }
-    const problem = await prisma.problem.findUnique({
-        where: { id: parseInt(problemId) },
+    const problem = await prisma.problem.findFirst({
+        where: { id: parseInt(problemId), is_active: true },
         include: { file: true },
     });
     if (!problem) {
@@ -280,7 +280,7 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
         problem_post: {
             update: {
                 current_size: getSizeCNF(problemCNF),
-                date_modified: (new Date()),
+                date_modified: new Date(),
                 is_active: !isSolved,
             },
         },
@@ -299,6 +299,16 @@ app.get("/api/problems", express.json(), async (req, res) => {
         badRequestError(res, "Unauthorized - Make sure you're logged in!", 403);
     } else {
         const problems = await prisma.problem.findMany({
+            where: {
+                OR: [
+                    {
+                        user_id: session.user.id,
+                    },
+                    {
+                        is_active: true,
+                    },
+                ],
+            },
             include: {
                 user: true,
             },
@@ -313,8 +323,18 @@ app.get("/api/problem/:problemId", express.json(), async (req, res) => {
     if (!session.user) {
         badRequestError(res, "Unauthorized - Make sure you're logged in!", 403);
     } else {
-        const problem = await prisma.problem.findUnique({
-            where: { id: parseInt(problemId) },
+        const problem = await prisma.problem.findFirst({
+            where: {
+                id: parseInt(problemId),
+                OR: [
+                    {
+                        user_id: session.user.id,
+                    },
+                    {
+                        is_active: true,
+                    },
+                ],
+            },
             include: { user: true },
         });
         if (!problem) {
@@ -331,8 +351,18 @@ app.get("/api/problem/:problemId/file", express.json(), async (req, res) => {
     if (!session.user) {
         badRequestError(res, "Unauthorized - Make sure you're logged in!", 403);
     } else {
-        const problem = await prisma.problem.findUnique({
-            where: { id: parseInt(problemId) },
+        const problem = await prisma.problem.findFirst({
+            where: {
+                id: parseInt(problemId),
+                OR: [
+                    {
+                        user_id: session.user.id,
+                    },
+                    {
+                        is_active: true,
+                    },
+                ],
+            },
             include: { file: true },
         });
         if (!problem) {

--- a/server/index.js
+++ b/server/index.js
@@ -306,7 +306,6 @@ app.put("/api/problem/:problemId/reduce", express.json(), async (req, res) => {
             total_size_reduced: newTotalReduction,
         },
     });
-    console.log(newUser);
     req.session.user = newUser;
     //TODO: Update size on the problem page
     res.json(update);

--- a/server/prisma/migrations/20250630214320_symmisolve_2/migration.sql
+++ b/server/prisma/migrations/20250630214320_symmisolve_2/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `poster` on the `Problem` table. All the data in the column will be lost.
-
-*/
--- AlterTable
-ALTER TABLE "Problem" DROP COLUMN "poster";

--- a/server/prisma/migrations/20250711180834_symmisolve/migration.sql
+++ b/server/prisma/migrations/20250711180834_symmisolve/migration.sql
@@ -14,11 +14,11 @@ CREATE TABLE "Problem" (
     "id" SERIAL NOT NULL,
     "user_id" INTEGER NOT NULL,
     "name" TEXT NOT NULL,
-    "poster" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "date_created" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "date_modified" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "current_size" INTEGER NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
 
     CONSTRAINT "Problem_pkey" PRIMARY KEY ("id")
 );

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Problem {
   date_created  DateTime @default(now())
   date_modified DateTime @default(now())
   current_size  Int
+  is_active     Boolean @default(true)
   file          ProblemFile  @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   user          User  @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }


### PR DESCRIPTION
### Context:
As part of MetaU Engineering program, i'm building Symmisolve. Symmisolve is a community-based Satisfiability solver. Since Satisfiability is a very difficult problem mathematically, solvers for this type of problem are all exponential in time. By leveraging human computing power, Symmisolve aims to create a SAT Solver based on human brain-power, as well as hosting interesting problems for both humans and machines to help solve. 
[Planning Document](https://docs.google.com/document/d/1pwZgnn_O9RFdl2ce4_BAM839tVD1qsia0_U7gMIm3GQ/edit?tab=t.0#heading=h.6b6nbvhbbspp)

### This PR
In this PR, I added a special state for problems which have been solved! They can now be viewed only by the person that uploaded them, who can view the reduction (which should be a solution) and the justification for the reduction. 
> There now exists a prompt to download the solution & reduced problem file when the problem is finished
<img width="290" height="243" alt="Screenshot 2025-07-11 at 5 11 33 PM" src="https://github.com/user-attachments/assets/c14af67e-d89d-44c3-a976-634a2e549654" />
> Solved problems now display with a [SOLVED] badge, to be reworked with the styling PR
<img width="1164" height="373" alt="Screenshot 2025-07-11 at 5 11 27 PM" src="https://github.com/user-attachments/assets/b83b071f-80aa-47e5-a263-94ba0f3b4520" />

## Changelog
- Added a status to problems indicating if the problem is solved or not
- Added checks so that only the user who uploaded a solved problem can view its solution
- Reductions can not be submitted to solved problems
- Users not authorized to view a solved problem will be redirected from all associated pages
- Users not authorized to view a solved problem will not see the problem appear in grids